### PR TITLE
Add support for empty strings

### DIFF
--- a/src/gd-ui-jsonexplorer.js
+++ b/src/gd-ui-jsonexplorer.js
@@ -132,7 +132,7 @@ angular.module('gd.ui.jsonexplorer', [])
 				};
 				
 				formatter.valueToHtml = function (value) {
-					var type = value && value.constructor;
+					var type = (value != null) && value.constructor;
 					var output = '';
 
 					if (value == null) {


### PR DESCRIPTION
Solves an issue that with a 

``` js
{
  emptyString: ''
}
```

the rendered json is 

``` json
{
  "emptyString": 
}
```

instead of 

``` json
{
  "emptyString": "" 
}
```
