### PR TITLE
Escape html from string values.

### DIFF
--- a/demo/data.js
+++ b/demo/data.js
@@ -15,6 +15,7 @@
     "phone": "+1 (813) 412-3935",
     "address": "632 Madoc Avenue, Woodburn, Minnesota, 2232",
     "about": "Mollit elit dolore aliqua laborum elit. Eu commodo labore non cupidatat. Labore esse amet amet in aliquip ullamco incididunt sunt veniam laborum. Anim tempor est irure veniam. Minim enim eiusmod proident irure.\r\n",
+    "html": "<html><h1>This is HTML</h1></html>",
     "registered": "2014-10-26T10:19:03 +02:00",
     "latitude": -54.780526,
     "longitude": -172.80744,

--- a/src/angular-json-explorer.js
+++ b/src/angular-json-explorer.js
@@ -33,13 +33,16 @@ angular.module('ngJsonExplorer', [])
 			var isObject = function (v) {
 				return angular.isObject(v);
 			};
+			var escape = function (v) {
+				return v.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+			}
 			var parseRaw = function (k, v) {
 				var key = '';
 				if (k) {
 					key = '<span class="prop>">' + k + '</span>: ';
 				}
 				if (typeof v == 'string') {
-					return key + '<span class="string">"' + v + '"</span>';
+					return key + '<span class="string">"' + escape(v) + '"</span>';
 				}
 				if (typeof v == 'number') {
 					return key + '<span class="num">' + v + '</span>';


### PR DESCRIPTION
When a JSON string value contains HTML, this will escape it such that the html is not rendered by the browser.